### PR TITLE
Upgrade widestring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ winapi = { version = "0.3.8", features = [
     "shellapi",
     "winerror",
 ] }
-widestring = "0.4.0"
+widestring = "0.5.0"
 com = "0.2.0"
 once_cell = "1.3.1"
 webview2-sys = { path = "./webview2-sys", version = "0.1.0" }
@@ -27,9 +27,7 @@ webview2-sys = { path = "./webview2-sys", version = "0.1.0" }
 [dev-dependencies]
 winit = "0.24.0"
 native-windows-gui = { version = "1.0.4", features = ["high-dpi"] }
-winapi = { version = "0.3.9", features = [
-    "libloaderapi",
-] }
+winapi = { version = "0.3.9", features = ["libloaderapi"] }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
My project is using cargo deny to lint our dependencies and as such we try to keep duplicates to a minimum.
I don't think widestring is used on the public interface of the webview2 crate if that is the case can the patch version be incremented?