### PR TITLE
Add basic support for cookie manager

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1064,13 +1064,7 @@ impl WebView {
 }
 
 impl WebView_2 {
-    pub fn get_cookie_manager(&self) -> Result<CookieManager> {
-        let mut ppv: *mut *mut ICoreWebView2CookieManagerVTable = ptr::null_mut();
-        check_hresult(unsafe { self.inner.get_cookie_manager(&mut ppv) })?;
-        Ok(CookieManager {
-            inner: unsafe { add_ref_to_rc(ppv) },
-        })
-    }
+    get_interface!(get_cookie_manager, CookieManager);
 }
 
 impl CookieManager {


### PR DESCRIPTION
Adds basic support for accessing cookies from webview2.

- Added complete Cookie implementation.
- Added complete CookieList implementation.
- Added 3 out of 8 CookieManager methods.
- Added `get_webview2` to `WebView`
- Added `get_cookie_manager` to `WebView_2` (1 out of 7)
